### PR TITLE
Delete _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-modernist


### PR DESCRIPTION
Se elimina _config.yml porque está interfiriendo con la renderizacion de los estilos CSS